### PR TITLE
fix comment highlighting

### DIFF
--- a/syntax/praat.vim
+++ b/syntax/praat.vim
@@ -40,7 +40,7 @@ syn match praatFunction '[a-z\-A-Z_ ]\+: \@='
 syn match praatFunction '[A-Z][ &a-z\-A-Z_]\+\(\.\.\.\|$\)'
 
 " Comments
-syn match praatComment '#.*$'
+syn match praatComment '^\s*#.*$'
 
 " Link it
 hi def link praatConditional Conditional


### PR DESCRIPTION
Thanks for this useful plugin! This PR fixes a minor error where non-comments are highlighted as comments. (Praat only treats lines where the first non-whitespace character is '#' as comments, and '#' is also used in the names of vectors/matrices.)